### PR TITLE
Added '/user/sso' route.

### DIFF
--- a/src/Controller/Ssofact.php
+++ b/src/Controller/Ssofact.php
@@ -10,7 +10,10 @@ class Ssofact extends ControllerBase {
    * {@inheritdoc}
    */
   public function content() {
-    return [];
+    return [
+      '#title' => '{{ title }}',
+      '#markup' => '{{ content }}',
+    ];
   }
 
 }

--- a/src/Controller/Ssofact.php
+++ b/src/Controller/Ssofact.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Drupal\ssofact\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+
+class Ssofact extends ControllerBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function content() {
+    return [];
+  }
+
+}

--- a/ssofact.module
+++ b/ssofact.module
@@ -5,6 +5,8 @@
  * Contains ssofact.module.
  */
 
+use Drupal\Component\Utility\Unicode;
+use Drupal\Component\Utility\UrlHelper;
 use Drupal\Core\Routing\RouteMatchInterface;
 
 /**
@@ -18,5 +20,54 @@ function ssofact_help($route_name, RouteMatchInterface $route_match) {
       $output .= '<h3>' . t('About') . '</h3>';
       $output .= '<p>' . t('OpenID Connect provider for Newsfactory ssoFACT.') . '</p>';
       return $output;
+  }
+}
+
+/**
+ * Implements hook_css_alter().
+ */
+function ssofact_css_alter(&$css) {
+  if (\Drupal::routeMatch()->getRouteName() !== 'ssofact.user') {
+    return;
+  }
+  ssofact_convert_asset_paths($css);
+}
+
+/**
+ * Implements hook_js_alter().
+ */
+function ssofact_js_alter(&$js) {
+  if (\Drupal::routeMatch()->getRouteName() !== 'ssofact.user') {
+    return;
+  }
+  ssofact_convert_asset_paths($js);
+}
+
+/**
+ * Implements hook_file_url_alter().
+ */
+function ssofact_file_url_alter(&$uri) {
+  if (\Drupal::routeMatch()->getRouteName() !== 'ssofact.user') {
+    return;
+  }
+  if (strpos($uri, '/') === 0) {
+    $uri = Unicode::substr($uri, 1);
+    $uri = $GLOBALS['base_url'] . '/' . UrlHelper::encodePath($uri);
+  }
+}
+
+/**
+ * Converts the paths of the given assets to be absolute.
+ *
+ * @param $assets
+ *   The assets objects to convert.
+ */
+function ssofact_convert_asset_paths(&$assets) {
+  foreach ($assets as $name => $asset) {
+    if ($asset['type'] !== 'file') {
+      continue;
+    }
+    $assets[$name]['data'] = file_create_url($asset['data']);
+    $assets[$name]['type'] = 'external';
   }
 }

--- a/ssofact.module
+++ b/ssofact.module
@@ -44,6 +44,12 @@ function ssofact_js_alter(&$js) {
 }
 
 /**
+ * Convert domain-relative URLs to absolute ones.
+ *
+ * The `ssofact.user` route markup will be used by ssoFACT as a template for
+ * user actions like login, signup and password reset. To render the template
+ * correctly, assets should have a full URL.
+ *
  * Implements hook_file_url_alter().
  */
 function ssofact_file_url_alter(&$uri) {

--- a/ssofact.routing.yml
+++ b/ssofact.routing.yml
@@ -5,3 +5,10 @@ ssofact.redirect_login:
     _title: 'OpenID Connect ssoFACT login form redirect page'
   requirements:
     _custom_access: '\Drupal\ssofact\Controller\SsofactRedirectController::access'
+ssofact.user:
+  path: '/user/sso'
+  defaults:
+    _controller: '\Drupal\ssofact\Controller\Ssofact::content'
+    _title: 'ssoFACT'
+  requirements:
+    _permission: 'change own username'

--- a/ssofact.routing.yml
+++ b/ssofact.routing.yml
@@ -11,6 +11,6 @@ ssofact.user:
     _controller: '\Drupal\ssofact\Controller\Ssofact::content'
     _title: 'ssoFACT'
   requirements:
-    _permission: 'change own username'
+    _permission: 'access content'
   options:
     no_cache: true

--- a/ssofact.routing.yml
+++ b/ssofact.routing.yml
@@ -12,3 +12,5 @@ ssofact.user:
     _title: 'ssoFACT'
   requirements:
     _permission: 'change own username'
+  options:
+    no_cache: true


### PR DESCRIPTION
This PR adds a blank `user/sso` route as requested from ssoFACT. For this particular route, the asset paths are absolute as the URL is used from the ssoFACT provider.

Issues:
- [x] The asset paths seems to get cached. When initially accessing `/user` and navigate to `/user/sso` the paths are relative. I am not sure why. Help welcome!