### PR TITLE
Added role_paywall module integration.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,15 @@
         "issues": "https://www.drupal.org/project/issues/ssofact",
         "source": "http://cgit.drupalcode.org/ssofact"
     },
+    "repositories": [
+      {
+        "type": "composer",
+        "url": "https://packages.drupal.org/8"
+      }
+    ],
     "minimum-stability": "dev",
     "require": {
+        "cweagans/composer-patches": "^1.6",
         "drupal/openid_connect": "1.x-dev",
         "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz/no-trailing-comma": "*"
     },
@@ -18,7 +25,8 @@
         "enable-patching": true,
         "patches": {
             "drupal/openid_connect": {
-                "Fix claim mapping for email": "https://www.drupal.org/files/issues/2018-07-30/openid_connect.email_.0.patch"
+                "Fix claim mapping for email": "https://www.drupal.org/files/issues/2018-07-30/openid_connect.email_.0.patch",
+                "Support destination definition as request parameter": "https://www.drupal.org/files/issues/2018-07-26/2988428-destination-by-request-param-1.patch"
             }
         }
     }

--- a/src/Controller/SsofactRedirectController.php
+++ b/src/Controller/SsofactRedirectController.php
@@ -47,7 +47,7 @@ class SsofactRedirectController extends ControllerBase implements AccessInterfac
    */
   public function access() {
     $query = $this->requestStack->getCurrentRequest()->query;
-    if ($query->get('code') && $query->get('target')) {
+    if ($query->get('code')) {
       return AccessResult::allowed();
     }
     return AccessResult::forbidden();

--- a/src/Event/SyncUserDataEvent.php
+++ b/src/Event/SyncUserDataEvent.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Drupal\ssofact\Event;
+
+use Drupal\user\UserInterface;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Implements event for user data sincroniztion.
+ */
+class SyncUserDataEvent extends Event {
+
+  const SYNC = 'event.sync_user_data';
+
+  protected $userInfo;
+
+  protected $user;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(UserInterface $user, array $userInfo) {
+    $this->user = $user;
+    $this->userInfo = $userInfo;
+  }
+
+  /**
+   * Get the user being synced.
+   */
+  public function getUser() {
+    return $this->user;
+  }
+
+  /**
+   * Get user info to sync.
+   */
+  public function getUserInfo() {
+    return $this->userInfo;
+  }
+
+}

--- a/src/Form/SsofactRegisterForm.php
+++ b/src/Form/SsofactRegisterForm.php
@@ -131,7 +131,7 @@ class SsofactRegisterForm extends FormBase implements ContainerInjectionInterfac
     $form['privacy'] = [
       '#type' => 'checkbox',
       '#required' => TRUE,
-      '#title' => $this->t('Please note the general <a href=":url_data">data protection regulations</a> and the <a href=":url_info">information obligation</a>.', [
+      '#title' => $this->t('Please note the general <a href=":url_data" target="_blank">data protection regulations</a> and the <a href=":url_info" target="_blank">information obligation</a>.', [
         ':url_data' => '/node/2',
         ':url_info' => 'https://www.stimme-medien.de/metanavigation/informationspflichten/',
       ]),

--- a/src/Form/SsofactRegisterForm.php
+++ b/src/Form/SsofactRegisterForm.php
@@ -86,6 +86,8 @@ class SsofactRegisterForm extends FormBase implements ContainerInjectionInterfac
       return $form;
     }
 
+    // Use custom redirect_uri for client-side login form, which does not check
+    // state token.
     $redirect_uri = Url::fromRoute('ssofact.redirect_login', [
       'client_name' => 'ssofact',
     ], [
@@ -144,6 +146,9 @@ class SsofactRegisterForm extends FormBase implements ContainerInjectionInterfac
 
     $form['#action'] = 'https://' . $server_domain . '/registrieren.html?' . http_build_query([
       'next' => $authorize_uri,
+      // Redirect to user account dashboard after clicking link in confirmation
+      // email.
+      'redirect_url' => Url::fromUri('internal:/shop/user/account', ['absolute' => TRUE])->toString(),
     ]);
 
     $form['actions'] = ['#type' => 'actions'];

--- a/src/Form/SsofactServerRegisterForm.php
+++ b/src/Form/SsofactServerRegisterForm.php
@@ -111,8 +111,9 @@ class SsofactServerRegisterForm extends FormBase implements ContainerInjectionIn
     ];
     $form['redirect_url'] = [
       '#type' => 'hidden',
-      // @todo Use current path.
-      '#value' => Url::fromUri('internal:/')->toString(),
+      // Redirect to user account dashboard after clicking link in confirmation
+      // email.
+      '#value' => Url::fromUri('internal:/shop/user/account', ['absolute' => TRUE])->toString(),
     ];
 
     $form['actions'] = ['#type' => 'actions'];

--- a/src/Form/SsofactServerRegisterForm.php
+++ b/src/Form/SsofactServerRegisterForm.php
@@ -7,17 +7,16 @@ use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\Url;
-use Drupal\Core\Routing\CurrentRouteMatch;
 use Drupal\openid_connect\OpenIDConnectClaims;
 use Drupal\openid_connect\Plugin\OpenIDConnectClientManager;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Class RegisterForm.
+ * Class ServerRegisterForm.
  *
  * @package Drupal\ssofact\Form
  */
-class SsofactRegisterForm extends FormBase implements ContainerInjectionInterface {
+class SsofactServerRegisterForm extends FormBase implements ContainerInjectionInterface {
 
   /**
    * Drupal\openid_connect\Plugin\OpenIDConnectClientManager definition.
@@ -34,13 +33,6 @@ class SsofactRegisterForm extends FormBase implements ContainerInjectionInterfac
   protected $claims;
 
   /**
-   * The current route match service.
-   *
-   * @var \Drupal\Core\Routing\RouteMatch
-   */
-  protected $routeMatch;
-
-  /**
    * The constructor.
    *
    * @param \Drupal\openid_connect\Plugin\OpenIDConnectClientManager $plugin_manager
@@ -50,13 +42,11 @@ class SsofactRegisterForm extends FormBase implements ContainerInjectionInterfac
    */
   public function __construct(
       OpenIDConnectClientManager $plugin_manager,
-      OpenIDConnectClaims $claims,
-      CurrentRouteMatch $route_match
+      OpenIDConnectClaims $claims
   ) {
 
     $this->pluginManager = $plugin_manager;
     $this->claims = $claims;
-    $this->routeMatch = $route_match;
   }
 
   /**
@@ -65,8 +55,7 @@ class SsofactRegisterForm extends FormBase implements ContainerInjectionInterfac
   public static function create(ContainerInterface $container) {
     return new static(
       $container->get('plugin.manager.openid_connect_client.processor'),
-      $container->get('openid_connect.claims'),
-      $container->get('current_route_match')
+      $container->get('openid_connect.claims')
     );
   }
 
@@ -74,7 +63,7 @@ class SsofactRegisterForm extends FormBase implements ContainerInjectionInterfac
    * {@inheritdoc}
    */
   public function getFormId() {
-    return 'ssofact_register_form';
+    return 'ssofact_server_register_form';
   }
 
   /**
@@ -85,22 +74,22 @@ class SsofactRegisterForm extends FormBase implements ContainerInjectionInterfac
     if (!$client_config->get('enabled')) {
       return $form;
     }
-
+    // Use custom redirect_uri for client-side login form, which does not check
+    // state token.
     $redirect_uri = Url::fromRoute('ssofact.redirect_login', [
       'client_name' => 'ssofact',
     ], [
       'absolute' => TRUE,
       'language' => \Drupal::languageManager()->getLanguage(LanguageInterface::LANGCODE_NOT_APPLICABLE),
       'query' => [
-        'target' => Url::fromRoute('<current>')->toString(),
+        'target' => Url::fromUri('internal:/')->toString(),
       ],
     ])->toString();
 
-    $server_domain = $client_config->get('settings.server_domain');
     $client_config = $client_config->get('settings');
     $client = $this->pluginManager->createInstance('ssofact', $client_config);
     $endpoints = $client->getEndpoints();
-    $authorize_uri = $endpoints['authorization'] . '?' . http_build_query([
+    $authorize_uri = $endpoints['user_create'] . '?' . http_build_query([
       'client_id' => $client_config['client_id'],
       'response_type' => 'code',
       'scope' => '',
@@ -109,6 +98,7 @@ class SsofactRegisterForm extends FormBase implements ContainerInjectionInterfac
 
     $form['email'] = [
       '#type' => 'email',
+      '#title' => $this->t('Your email address'),
       '#size' => 60,
       '#maxlength' => USERNAME_MAX_LENGTH,
       '#required' => TRUE,
@@ -117,41 +107,16 @@ class SsofactRegisterForm extends FormBase implements ContainerInjectionInterfac
         'autocapitalize' => 'none',
         'spellcheck' => 'false',
         'autofocus' => 'autofocus',
-        'placeholder' => $this->t('Your email address'),
       ],
     ];
-
-    $form['article_test'] = [
+    $form['redirect_url'] = [
       '#type' => 'hidden',
-      '#value' => $this->routeMatch->getRawParameter('node'),
+      // @todo Use current path.
+      '#value' => Url::fromUri('internal:/')->toString(),
     ];
-
-    $form['privacy'] = [
-      '#type' => 'checkbox',
-      '#required' => TRUE,
-      '#title' => $this->t('Please note the general <a href=":url_data">data protection regulations</a> and the <a href=":url_info">information obligation</a>.', [
-        ':url_data' => '/node/2',
-        ':url_info' => 'https://www.stimme-medien.de/metanavigation/informationspflichten/',
-      ]),
-      '#return_value' => '1',
-    ];
-
-    // Hiddes field with value "1" to enable 1-article-test registration.
-    $form['_qf__registerForm'] = [
-      '#type' => 'hidden',
-      '#value' => '1',
-    ];
-
-    $form['#action'] = 'https://' . $server_domain . '/registrieren.html?' . http_build_query([
-      'next' => $authorize_uri,
-    ]);
 
     $form['actions'] = ['#type' => 'actions'];
-    $form['actions']['submit'] = [
-      '#type' => 'submit',
-      '#value' => $this->t('Sign up'),
-    ];
-
+    $form['actions']['submit'] = ['#type' => 'submit', '#value' => $this->t('Sign up')];
     return $form;
   }
 
@@ -159,12 +124,36 @@ class SsofactRegisterForm extends FormBase implements ContainerInjectionInterfac
    * {@inheritdoc}
    */
   public function validateForm(array &$form, FormStateInterface $form_state) {
+    $client_config = $this->config('openid_connect.settings.ssofact')->get('settings');
+    $client = $this->pluginManager->createInstance('ssofact', $client_config);
+    $response = $client->createUser($form_state->getValue('email'));
+
+    if ($response['statuscode'] !== 200) {
+      foreach ($response['userMessages'] as $error_message) {
+        $form_state->setError($form['email'], $error_message);
+      }
+    }
+    if (empty($response['userId'])) {
+      $form_state->setError($form['email'], $this->t('Unable to register your account. Please contact our support.'));
+    }
+    else {
+      $form_state->setTemporaryValue('userId', $response['userId']);
+    }
   }
 
   /**
    * {@inheritdoc}
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
+    if ($sub = $form_state->getTemporaryValue('userId')) {
+      // @todo Redirect to SSO login?
+    }
+    // openid_connect_save_destination();
+
+    // $scopes = $this->claims->getScopes();
+    // $_SESSION['openid_connect_op'] = 'login';
+    // $response = $client->authorize($scopes, $form_state);
+    // $form_state->setResponse($response);
   }
 
 }

--- a/src/Plugin/Block/SsofactLoginBlock.php
+++ b/src/Plugin/Block/SsofactLoginBlock.php
@@ -145,7 +145,11 @@ class SsofactLoginBlock extends BlockBase implements ContainerFactoryPluginInter
       '#type' => 'link',
       '#title' => $this->t('Register here'),
       '#url' => Url::fromUri('https://' . $form['#server_domain'] . '/registrieren.html?' . http_build_query([
+        // Redirect to current page immediately after registering and logging in.
         'next' => \Drupal::request()->get('destination') ?: Url::fromRoute('user.page', [], ['absolute' => TRUE])->toString(),
+        // Redirect to user account dashboard after clicking link in confirmation
+        // email.
+        'redirect_url' => Url::fromUri('internal:/shop/user/account', ['absolute' => TRUE])->toString(),
       ])),
       '#attributes' => [
         'title' => $this->t('Create a new user account.'),

--- a/src/Plugin/Block/SsofactRegisterBlock.php
+++ b/src/Plugin/Block/SsofactRegisterBlock.php
@@ -102,18 +102,19 @@ class SsofactRegisterBlock extends BlockBase implements ContainerFactoryPluginIn
 
     // Build action links.
     $items = [];
-    if (\Drupal::config('user.settings')->get('register') != USER_REGISTER_ADMINISTRATORS_ONLY) {
-      $items['login'] = [
-        '#type' => 'link',
-        '#title' => $this->t('Log in'),
-        '#url' => Url::fromRoute('user.login', [], [
-          'attributes' => [
-            'title' => $this->t('Log in with your existing account.'),
+    $items['login'] = [
+      '#type' => 'link',
+      '#title' => $this->t('Log in'),
+      '#url' => Url::fromRoute('user.login', [], [
+        'query' => [
+          'destination' => Url::fromRoute('<current>', [], ['absolute' => TRUE])->toString(),
+        ],
+        'attributes' => [
+          'title' => $this->t('Log in with your existing account.'),
             'class' => ['login-link'],
           ],
         ]),
-      ];
-    }
+    ];
     $items['request_password'] = [
       '#type' => 'link',
       '#title' => $this->t('Reset your password'),

--- a/src/Plugin/Block/SsofactRegisterBlock.php
+++ b/src/Plugin/Block/SsofactRegisterBlock.php
@@ -107,7 +107,7 @@ class SsofactRegisterBlock extends BlockBase implements ContainerFactoryPluginIn
       '#title' => $this->t('Log in'),
       '#url' => Url::fromRoute('user.login', [], [
         'query' => [
-          'destination' => Url::fromRoute('<current>', [], ['absolute' => TRUE])->toString(),
+          'destination' => Url::fromRoute('<current>')->toString(),
         ],
         'attributes' => [
           'title' => $this->t('Log in with your existing account.'),

--- a/src/Plugin/Block/SsofactServerRegisterBlock.php
+++ b/src/Plugin/Block/SsofactServerRegisterBlock.php
@@ -15,12 +15,12 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * Provides a user login block.
  *
  * @Block(
- *   id = "ssofact_register_block",
- *   admin_label = @Translation("User register (ssoFACT)"),
+ *   id = "ssofact_server_register_block",
+ *   admin_label = @Translation("User server register (ssoFACT)"),
  *   category = @Translation("Forms")
  * )
  */
-class SsofactRegisterBlock extends BlockBase implements ContainerFactoryPluginInterface {
+class SsofactServerRegisterBlock extends BlockBase implements ContainerFactoryPluginInterface {
 
   use RedirectDestinationTrait;
 
@@ -79,7 +79,7 @@ class SsofactRegisterBlock extends BlockBase implements ContainerFactoryPluginIn
    * {@inheritdoc}
    */
   public function build() {
-    $form = \Drupal::formBuilder()->getForm('Drupal\ssofact\Form\SsofactRegisterForm');
+    $form = \Drupal::formBuilder()->getForm('Drupal\ssofact\Form\SsofactServerRegisterForm');
     unset($form['email']['#attributes']['autofocus']);
     $form['email']['#size'] = 15;
 
@@ -125,12 +125,7 @@ class SsofactRegisterBlock extends BlockBase implements ContainerFactoryPluginIn
       ]),
     ];
     return [
-      '#title' => $this->t('Continue reading?'),
-      'description' => [
-        '#type' => 'markup',
-        '#markup' => $this->t('Enter your e-mail address to unlock this post for free'),
-      ],
-      'user_register_form' => $form,
+      'user_server_register_form' => $form,
       'user_links' => [
         '#theme' => 'item_list',
         '#items' => $items,

--- a/src/Plugin/OpenIDConnectClient/Ssofact.php
+++ b/src/Plugin/OpenIDConnectClient/Ssofact.php
@@ -22,6 +22,7 @@ class Ssofact extends OpenIDConnectClientBase {
   const ENDPOINT_END_SESSION = '/REST/oauth/logout';
 
   const ENDPOINT_USER_CREATE = '/REST/services/authenticate/user/registerUser';
+  const ENDPOINT_IS_EMAIL_REGISTERED = '/REST/services/authenticate/user/IsEmailRegistered';
 
   const ROUTE_REDIRECT = 'ssofact.redirect';
 
@@ -89,7 +90,7 @@ class Ssofact extends OpenIDConnectClientBase {
    */
   public function authorize($scope = 'openid email') {
     // Non-empty scope triggers error:
-    // "Authorization failed: invalid_scope. Details: Unsupported Scope"
+    // "Authorization failed: invalid_scope. Details: Unsupported Scope".
     return parent::authorize($this->configuration['scope']);
   }
 
@@ -173,6 +174,27 @@ class Ssofact extends OpenIDConnectClientBase {
         ]);
       throw $e;
     }
+  }
+
+  public function isEmailRegistered($email) {
+    $rfbe_key = $this->configuration['rfbe_key'];
+    $rfbe_secret = $this->configuration['rfbe_secret'];
+    $api_url = 'https://' . $this->configuration['server_domain'] . static::ENDPOINT_IS_EMAIL_REGISTERED;
+    $client = \Drupal::httpClient();
+    $request = $client->post($api_url, [
+      'body' => json_encode(['email' => $email]),
+      'headers' => [
+        'Content-type' => 'application/json',
+        'Accept' => 'application/json',
+        'rfbe-key' => $rfbe_key,
+        'rfbe-secret' => $rfbe_secret,
+      ],
+    ]);
+    $response = json_decode($request->getBody());
+    return [
+      'status' => (int) $response->statuscode,
+      'message' => $response->userMessages[0],
+    ];
   }
 
 }

--- a/ssofact.info.yml
+++ b/ssofact.info.yml
@@ -5,3 +5,5 @@ core: 8.x
 package: Other
 dependencies:
   - openid_connect
+'interface translation project': ssofact
+'interface translation server pattern': modules/contrib/ssofact/translations/%language.po

--- a/ssofact.module
+++ b/ssofact.module
@@ -12,6 +12,7 @@ use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Session\AccountProxy;
+use Drupal\ssofact\Event\SyncUserDataEvent;
 use Drupal\user\UserInterface;
 
 /**
@@ -42,40 +43,15 @@ function ssofact_openid_connect_user_properties_ignore_alter(array &$properties_
  */
 function ssofact_openid_connect_userinfo_save(UserInterface $account, $context) {
   $userinfo = $context['userinfo'];
-  if (!empty($userinfo['confirmed']) && empty($userinfo['deactivated'])) {
+  if (empty($userinfo['deactivated'])) {
     $account->activate();
   }
   else {
     $account->block();
   }
 
-  // @todo Use role name from configuration.
-  if (!empty($userinfo['alfa_purchases']['purchases']) && ssofact_is_user_active_subscriber($userinfo['alfa_purchases']['purchases'])) {
-    $account->addRole('subscriber');
-  }
-  else {
-    $account->removeRole('subscriber');
-  }
-}
-
-/**
- * Returns whether a given list of purchases contains any active subscription granting access to premium online articles.
- *
- * @param array $purchases
- *   The value of "alfa_purchases" from the SSO UserInfo.
- *
- * @return bool
- */
-function ssofact_is_user_active_subscriber(array $purchases) {
-  $today = date('Ymd');
-  foreach ($purchases as $access) {
-    if ($access['purchase']['fromDay'] <= $today && $access['purchase']['toDay'] >= $today) {
-      if ($access['purchase']['object'] === 'OABO') {
-        return TRUE;
-      }
-    }
-  }
-  return FALSE;
+  // Trigger event to let 3rd party to subscribe and alter.
+  \Drupal::service('event_dispatcher')->dispatch(SyncUserDataEvent::SYNC, new SyncUserDataEvent($account, $userinfo));
 }
 
 /**

--- a/translations/de.po
+++ b/translations/de.po
@@ -93,8 +93,8 @@ msgid "Your email address"
 msgstr "E-Mail-Adresse"
 
 #: modules/contrib/ssofact/src/Form/SsofactRegisterForm.php:144
-msgid "Please note the general <a href=\":url_data\">data protection regulations</a> and the <a href=\":url_info\">information obligation</a>."
-msgstr "Bitte beachten Sie die allgemeinen <a href=\":url_data\">Datenschutzbestimmungen</a> und die <a href=\":url_info\">Informationspflicht</a>."
+msgid "Please note the general <a href=\":url_data\" target=\"_blank\">data protection regulations</a> and the <a href=\":url_info\" target=\"_blank\">information obligation</a>."
+msgstr "Bitte beachten Sie die allgemeinen <a href=\":url_data\" target=\"_blank\">Datenschutzbestimmungen</a> und die <a href=\":url_info\" target=\"_blank\">Informationspflicht</a>."
 
 #: modules/contrib/ssofact/src/Form/SsofactRegisterForm.php:161 modules/contrib/ssofact/src/Form/SsofactServerRegisterForm.php:119
 msgid "Sign up"

--- a/translations/de.po
+++ b/translations/de.po
@@ -1,0 +1,157 @@
+# $Id$
+#
+# LANGUAGE translation of Drupal (general)
+# Copyright YEAR NAME <EMAIL@ADDRESS>
+# Generated from files:
+#  modules/contrib/ssofact/ssofact.module: n/a
+#  modules/contrib/ssofact/ssofact.info.yml: n/a
+#  modules/contrib/ssofact/ssofact.routing.yml: n/a
+#  modules/contrib/ssofact/config/schema/ssofact.schema.yml: n/a
+#  modules/contrib/ssofact/src/Plugin/OpenIDConnectClient/Ssofact.php: n/a
+#  modules/contrib/ssofact/src/Form/SsofactLoginForm.php: n/a
+#  modules/contrib/ssofact/src/Plugin/Block/SsofactRegisterBlock.php: n/a
+#  modules/contrib/ssofact/src/Plugin/Block/SsofactServerRegisterBlock.php: n/a
+#  modules/contrib/ssofact/src/Form/SsofactRegisterForm.php: n/a
+#  modules/contrib/ssofact/src/Form/SsofactServerRegisterForm.php: n/a
+#  modules/contrib/ssofact/src/Plugin/Block/SsofactLoginBlock.php: n/a
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"POT-Creation-Date: 2018-07-29 19:49+0200\n"
+"PO-Revision-Date: YYYY-mm-DD HH:MM+ZZZZ\n"
+"Last-Translator: NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <EMAIL@ADDRESS>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+#: modules/contrib/ssofact/ssofact.module:23
+msgid "About"
+msgstr ""
+
+#: modules/contrib/ssofact/ssofact.module:24 modules/contrib/ssofact/ssofact.info.yml:0
+msgid "OpenID Connect provider for Newsfactory ssoFACT."
+msgstr ""
+
+#: modules/contrib/ssofact/ssofact.info.yml:0
+msgid "OpenID Connect Newsfactory ssoFACT Client"
+msgstr ""
+
+#: modules/contrib/ssofact/ssofact.info.yml:0
+msgid "Other"
+msgstr ""
+
+#: modules/contrib/ssofact/ssofact.routing.yml:0
+msgid "OpenID Connect ssoFACT login form redirect page"
+msgstr ""
+
+#: modules/contrib/ssofact/ssofact.routing.yml:0
+msgid "ssoFACT"
+msgstr ""
+
+#: modules/contrib/ssofact/config/schema/ssofact.schema.yml:0
+msgid "OpenID Connect Newsfactory ssoFACT settings"
+msgstr ""
+
+#: modules/contrib/ssofact/config/schema/ssofact.schema.yml:0
+msgid "Enable client"
+msgstr ""
+
+#: modules/contrib/ssofact/config/schema/ssofact.schema.yml:0
+msgid "Client ID"
+msgstr ""
+
+#: modules/contrib/ssofact/config/schema/ssofact.schema.yml:0
+msgid "Client secret"
+msgstr ""
+
+#: modules/contrib/ssofact/config/schema/ssofact.schema.yml:0 modules/contrib/ssofact/src/Plugin/OpenIDConnectClient/Ssofact.php:50
+msgid "Server domain"
+msgstr ""
+
+#: modules/contrib/ssofact/src/Form/SsofactLoginForm.php:137
+msgid "Stay logged-in"
+msgstr "Angemeldet bleiben"
+
+#: modules/contrib/ssofact/src/Form/SsofactLoginForm.php:145
+msgid "Forgot password?"
+msgstr "Passwort vergessen?"
+
+#: modules/contrib/ssofact/src/Form/SsofactLoginForm.php:151 modules/contrib/ssofact/src/Plugin/Block/SsofactRegisterBlock.php:122 modules/contrib/ssofact/src/Plugin/Block/SsofactServerRegisterBlock.php:122
+msgid "Send password reset instructions via email."
+msgstr "Anleitung zur Rücksetzung des Passworts per Mail senden."
+
+#: modules/contrib/ssofact/src/Form/SsofactLoginForm.php:165 modules/contrib/ssofact/src/Plugin/Block/SsofactRegisterBlock.php:108 modules/contrib/ssofact/src/Plugin/Block/SsofactServerRegisterBlock.php:108
+msgid "Log in"
+msgstr "Anmelden"
+
+#: modules/contrib/ssofact/src/Form/SsofactRegisterForm.php:123 modules/contrib/ssofact/src/Form/SsofactServerRegisterForm.php:101
+msgid "Your email address"
+msgstr "E-Mail-Adresse"
+
+#: modules/contrib/ssofact/src/Form/SsofactRegisterForm.php:144
+msgid "Please note the general <a href=\":url_data\">data protection regulations</a> and the <a href=\":url_info\">information obligation</a>."
+msgstr "Bitte beachten Sie die allgemeinen <a href=\":url_data\">Datenschutzbestimmungen</a> und die <a href=\":url_info\">Informationspflicht</a>."
+
+#: modules/contrib/ssofact/src/Form/SsofactRegisterForm.php:161 modules/contrib/ssofact/src/Form/SsofactServerRegisterForm.php:119
+msgid "Sign up"
+msgstr "Registrieren"
+
+#: modules/contrib/ssofact/src/Form/SsofactServerRegisterForm.php:137
+msgid "Unable to register your account. Please contact our support."
+msgstr "Ihr Zugangdaten können nicht registriert werden. Bitte kontaktieren Sie unseren Support."
+
+#: modules/contrib/ssofact/src/Plugin/Block/SsofactLoginBlock.php:146
+msgid "Register here"
+msgstr "Hier registrieren"
+
+#: modules/contrib/ssofact/src/Plugin/Block/SsofactLoginBlock.php:151
+msgid "Create a new user account."
+msgstr "Neues Benutzerkonto erstellen."
+
+#: modules/contrib/ssofact/src/Plugin/Block/SsofactLoginBlock.php:14
+msgid "User login (ssoFACT)"
+msgstr ""
+
+#: modules/contrib/ssofact/src/Plugin/Block/SsofactLoginBlock.php:14 modules/contrib/ssofact/src/Plugin/Block/SsofactRegisterBlock.php:14 modules/contrib/ssofact/src/Plugin/Block/SsofactServerRegisterBlock.php:14
+msgid "Forms"
+msgstr ""
+
+#: modules/contrib/ssofact/src/Plugin/Block/SsofactRegisterBlock.php:111 modules/contrib/ssofact/src/Plugin/Block/SsofactServerRegisterBlock.php:111
+msgid "Log in with your existing account."
+msgstr "Mit bestehendem Konto anmelden."
+
+#: modules/contrib/ssofact/src/Plugin/Block/SsofactRegisterBlock.php:119 modules/contrib/ssofact/src/Plugin/Block/SsofactServerRegisterBlock.php:119
+msgid "Reset your password"
+msgstr "Passwort zurücksetzen"
+
+#: modules/contrib/ssofact/src/Plugin/Block/SsofactRegisterBlock.php:128
+msgid "Continue reading?"
+msgstr "Weiterlesen?"
+
+#: modules/contrib/ssofact/src/Plugin/Block/SsofactRegisterBlock.php:131
+msgid "Enter your e-mail address to unlock this post for free"
+msgstr "Bitte geben Sie Ihre E-Mail-Adresse an, um diesen Beitrag gratis freizuschalten"
+
+#: modules/contrib/ssofact/src/Plugin/Block/SsofactRegisterBlock.php:14
+msgid "User register (ssoFACT)"
+msgstr ""
+
+#: modules/contrib/ssofact/src/Plugin/Block/SsofactServerRegisterBlock.php:14
+msgid "User server register (ssoFACT)"
+msgstr ""
+
+#: modules/contrib/ssofact/src/Plugin/OpenIDConnectClient/Ssofact.php:122
+msgid "Userinfo: @userinfo"
+msgstr ""
+
+#: modules/contrib/ssofact/src/Plugin/OpenIDConnectClient/Ssofact.php:165
+msgid "User register response: @response"
+msgstr ""
+
+#: modules/contrib/ssofact/src/Plugin/OpenIDConnectClient/Ssofact.php:172
+msgid "User register failed: @error_message"
+msgstr ""


### PR DESCRIPTION
I guess enough feature is there and we can start with review - move it forward.

Basically implements all SsoFact needs for 1-article-text
 - form
 - block
 - redirects and fixes for the auth
 - make it pluggable to store custom data from the 1-article-test module.

Depends on https://www.drupal.org/project/openid_connect/issues/2988428

TODO:
 - [x] Add the patch to the `composer.json` file 