### PR TITLE
fixup! Added redirect URL for email confirmation link to login/register forms. (#12)

### DIFF
--- a/src/Form/SsofactRegisterForm.php
+++ b/src/Form/SsofactRegisterForm.php
@@ -121,13 +121,6 @@ class SsofactRegisterForm extends FormBase implements ContainerInjectionInterfac
       ],
     ];
 
-    $form['redirect_url'] = [
-      '#type' => 'hidden',
-      // Redirect to user account dashboard after clicking link in confirmation
-      // email.
-      '#value' => Url::fromUri('internal:/shop/user/account', ['absolute' => TRUE])->toString(),
-    ];
-
     $form['article_test'] = [
       '#type' => 'hidden',
       '#value' => $this->routeMatch->getRawParameter('node'),
@@ -148,6 +141,9 @@ class SsofactRegisterForm extends FormBase implements ContainerInjectionInterfac
 
     $form['#action'] = 'https://' . $server_domain . '/registrieren.html?' . http_build_query([
       'next' => $authorize_uri,
+      // Redirect to user account dashboard after clicking link in confirmation
+      // email.
+      'redirect_url' => Url::fromUri('internal:/shop/user/account', ['absolute' => TRUE])->toString(),
     ]);
 
     $form['actions'] = ['#type' => 'actions'];


### PR DESCRIPTION
Sorry, the redirect_url parameter is a GET parameter, not a POST parameter.