### PR TITLE
Fixed auto-login is not triggered because responses are served from page_cache middleware for anonymous users.

### DIFF
--- a/src/PageCache/DefaultRequestPolicy.php
+++ b/src/PageCache/DefaultRequestPolicy.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Drupal\ssofact\PageCache;
+
+use Drupal\ssofact\PageCache\RequestPolicy\SessionCookieRequestPolicy;
+use Drupal\Core\Session\SessionConfigurationInterface;
+use Drupal\Core\PageCache\DefaultRequestPolicy as PageCacheRequestPolicy;
+
+/**
+ * Overrides the default page cache policy service.
+ *
+ * Add a custom rule for ssoFACT session cookies.
+ * Disallows serving responses from page cache for requests with a ssoFACT
+ * session cookie.
+ */
+class DefaultRequestPolicy extends PageCacheRequestPolicy {
+
+  /**
+   * Constructs the default page cache request policy.
+   */
+  public function __construct(SessionConfigurationInterface $session_configuration) {
+    parent::__construct($session_configuration);
+    $this->addPolicy(new SessionCookieRequestPolicy());
+  }
+
+}

--- a/src/PageCache/RequestPolicy/SessionCookieRequestPolicy.php
+++ b/src/PageCache/RequestPolicy/SessionCookieRequestPolicy.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Drupal\ssofact\PageCache\RequestPolicy;
+
+use Drupal\Core\PageCache\RequestPolicyInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Reject caching when the user has the sso cookie.
+ */
+class SessionCookieRequestPolicy implements RequestPolicyInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function check(Request $request) {
+    if ($request->cookies->has('RF_OAUTH_SERVER')) {
+      return static::DENY;
+    }
+  }
+
+}

--- a/src/SsofactServiceProvider.php
+++ b/src/SsofactServiceProvider.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Drupal\ssofact;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\DependencyInjection\ServiceProviderBase;
+
+/**
+ * Modifies the page_cache_request_policy service.
+ */
+class SsofactServiceProvider extends ServiceProviderBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alter(ContainerBuilder $container) {
+    $definition = $container->getDefinition('page_cache_request_policy');
+    $definition->setClass('Drupal\ssofact\PageCache\DefaultRequestPolicy');
+  }
+
+}


### PR DESCRIPTION
Do not serve cached responses when the oauth cookie is present.