### PR TITLE
Fixed registration form redirects to 404 page after signup.

### DIFF
--- a/src/Plugin/Block/SsofactLoginBlock.php
+++ b/src/Plugin/Block/SsofactLoginBlock.php
@@ -148,7 +148,7 @@ class SsofactLoginBlock extends BlockBase implements ContainerFactoryPluginInter
       '#title' => $this->t('Register here'),
       '#url' => Url::fromUri('https://' . $form['#server_domain'] . '/registrieren.html?' . http_build_query([
         // Redirect to current page immediately after registering and logging in.
-        'next' => \Drupal::request()->get('destination') ?: Url::fromRoute('user.page', [], ['absolute' => TRUE])->toString(),
+        'next' => \Drupal::request()->get('destination') ? Url::fromUri('internal:' . \Drupal::request()->get('destination'), ['absolute' => TRUE])->toString() : Url::fromRoute('user.page', [], ['absolute' => TRUE])->toString(),
         // Redirect to user account dashboard after clicking link in confirmation
         // email.
         'redirect_url' => Url::fromUri('internal:/shop/user/account', ['absolute' => TRUE])->toString(),


### PR DESCRIPTION
Ticket: https://app.asana.com/0/633061025239778/938422990510237/f

A domain-relative path is resolved locally on the SSO domain (where the originating page does not exist).